### PR TITLE
Support nested countries and regions i18n access

### DIFF
--- a/src/components/country-select.vue
+++ b/src/components/country-select.vue
@@ -57,7 +57,7 @@ export default {
       if (this.usei18n && this.$i18n) {
         countryList = countryList.map((country) => {
           let localeCountry = Object.assign({}, country);
-          localeCountry.countryName = this.$t(country.countryName);
+          localeCountry.countryName = this.$t(`countries.${country.countryName}`);
           return localeCountry;
         });
         countryList.sort((country1, country2) => {
@@ -114,7 +114,7 @@ export default {
         }
       });
       if (this.usei18n && this.$i18n) {
-        return this.$t(regionObj.countryName);
+        return this.$t(`countries.${regionObj.countryName}`);
       }
       return this.shortCodeDropdown
         ? regionObj.countryShortCode

--- a/src/components/region-select.vue
+++ b/src/components/region-select.vue
@@ -78,7 +78,7 @@ export default {
       if (this.usei18n && this.$i18n) {
         countryRegions = countryRegions.map((region) => {
           let localeRegion = Object.assign({}, region)
-          localeRegion.name = this.$t(region.name)
+          localeRegion.name = this.$t(`regions.${region.name}`)
           return localeRegion
         })
         countryRegions.sort((region1, region2) => {


### PR DESCRIPTION
### Overview
Since we want to nest all the countries and Japan regions in the locale file to countries and regions respectively, we need to support that by changing the way `$t` is accessed on the `country-select` and `region-select` components.