### PR TITLE
removed files config from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vue3-country-region-select",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
     "lint": "vue-cli-service lint",
     "e2e:open": "vue-cli-service e2e:open"
   },
-  "files": [
-    "dist/vueCountryRegionSelect.umd.min.js"
-  ],
   "main": "./dist/vueCountryRegionSelect.umd.min.js",
   "dependencies": {
     "vue": "^3.0.0",


### PR DESCRIPTION
removed `files` config from `package.json` to prevent yarn from only installing `dist` folder instead of the actual source code